### PR TITLE
Feat: CRUD de licencias 

### DIFF
--- a/backend/dashboard_api/models.py
+++ b/backend/dashboard_api/models.py
@@ -86,7 +86,6 @@ class License(models.Model):
 class Certificate(models.Model):
     certificate_id = models.AutoField(primary_key=True)
     license = models.OneToOneField(License, on_delete=models.CASCADE, related_name='certificate')
-    path = models.CharField(max_length=255, blank=True, null=True)
     file = models.TextField(blank=True, null=True)
     validation = models.BooleanField(default=False)
     upload_date = models.DateTimeField(auto_now_add=True)

--- a/backend/dashboard_api/models.py
+++ b/backend/dashboard_api/models.py
@@ -75,22 +75,23 @@ class License(models.Model):
         # Si cambió el estado de is_deleted a True
         if not is_new and old_is_deleted is False and self.is_deleted is True:
             try:
-                certificado = self.certificado
-                certificado.is_deleted = True
-                certificado.deleted_at = timezone.now()
-                certificado.save()
+                certificate = self.certificate
+                certificate.is_deleted = True
+                certificate.deleted_at = timezone.now()
+                certificate.save()
             except Certificate.DoesNotExist:
                 pass  # No tiene certificado, no hacemos nada
 
 
 class Certificate(models.Model):
     certificate_id = models.AutoField(primary_key=True)
-    license = models.OneToOneField('License', on_delete=models.CASCADE, related_name='certificate')
-    path = models.CharField(max_length=255)
+    license = models.OneToOneField(License, on_delete=models.CASCADE, related_name='certificate')
+    path = models.CharField(max_length=255, blank=True, null=True)
+    file = models.TextField(blank=True, null=True)
     validation = models.BooleanField(default=False)
-    upload_date = models.DateField()
+    upload_date = models.DateTimeField(auto_now_add=True)
     is_deleted = models.BooleanField(default=False)
-    deleted_at = models.DateTimeField(blank=True, null=True)
+    deleted_at = models.DateTimeField(null=True, blank=True)
 
     def __str__(self):
         return f"Certificado {self.certificate_id} - Licencia {self.license.license_id}"

--- a/backend/dashboard_api/models.py
+++ b/backend/dashboard_api/models.py
@@ -1,4 +1,5 @@
-from datetime import timezone
+from datetime import datetime
+from django.utils import timezone
 from django.conf import settings
 from django.db import models
 from django.contrib.auth.models import AbstractUser

--- a/backend/dashboard_api/urls.py
+++ b/backend/dashboard_api/urls.py
@@ -9,6 +9,6 @@ urlpatterns = [
 
     path('licenses', licenses_list,name='licenses_list'),
     path('licenses/request', create_license, name='create_license'),
-
+    path('licenses/<int:id>', delete_license, name='delete-license'),
      
 ]

--- a/backend/dashboard_api/urls.py
+++ b/backend/dashboard_api/urls.py
@@ -8,5 +8,7 @@ urlpatterns = [
     path('users/update/<int:id>', update_user, name='update_user'),
 
     path('licenses', licenses_list,name='licenses_list'),
+    path('licenses/request', create_license, name='create_license'),
+
      
 ]

--- a/backend/dashboard_api/views.py
+++ b/backend/dashboard_api/views.py
@@ -1,5 +1,6 @@
 import base64
 from django.core.files.base import ContentFile
+from django.utils import timezone
 from datetime import datetime
 from django.utils.timezone import get_current_timezone
 from django.contrib.auth import get_user_model
@@ -255,3 +256,20 @@ def create_license(request):
 
     except Exception as e:
         return JsonResponse({'error': str(e)}, status=500)
+
+
+@csrf_exempt
+@require_http_methods(["DELETE"])
+def delete_license(request, id):
+    if not id:
+        return JsonResponse({'error': 'El ID es requerido.'}, status=400)
+
+    try:
+        license_obj = License.objects.get(license_id=id, is_deleted=False)
+        license_obj.is_deleted = True
+        license_obj.deleted_at = timezone.now()
+        license_obj.save()
+        return JsonResponse({'message': 'Licencia eliminada correctamente.'}, status=200)
+
+    except License.DoesNotExist:
+        return JsonResponse({'error': 'La licencia no existe.'}, status=404)

--- a/backend/dashboard_api/views.py
+++ b/backend/dashboard_api/views.py
@@ -1,3 +1,5 @@
+import base64
+from django.core.files.base import ContentFile
 from datetime import datetime
 from django.utils.timezone import get_current_timezone
 from django.contrib.auth import get_user_model
@@ -236,14 +238,19 @@ def create_license(request):
         )
 
         if certificate_data:
-            Certificate.objects.create(
-                license=license,
-                path=certificate_data.get('path', ''),
-                validation=certificate_data.get('validation', False),
-                upload_date=datetime.now(),
-                is_deleted=False,
-                deleted_at=None
-            )
+            # Obtención del archivo en base64
+            file_data = certificate_data.get('file', None)
+            if file_data:
+                # Almacenamos el archivo en base64
+                Certificate.objects.create(
+                    license=license,
+                    path=certificate_data.get('path', ''),
+                    file=file_data,  # Aquí guardamos el string base64
+                    validation=certificate_data.get('validation', False),
+                    upload_date=datetime.now(),
+                    is_deleted=False,
+                    deleted_at=None
+                )
 
         return JsonResponse({'message': 'Licencia solicitada exitosamente.'}, status=200)
 

--- a/backend/dashboard_api/views.py
+++ b/backend/dashboard_api/views.py
@@ -244,7 +244,6 @@ def create_license(request):
                 # Almacenamos el archivo en base64
                 Certificate.objects.create(
                     license=license,
-                    path=certificate_data.get('path', ''),
                     file=file_data,  # Aquí guardamos el string base64
                     validation=certificate_data.get('validation', False),
                     upload_date=datetime.now(),


### PR DESCRIPTION
Se agregan endpoints de CRUD para solicitar y eliminar solicitudes de licencias con sus certificados.

**Cards de Trello:**
CRUD Licencias - Crear solicitud de licencia
CRUD Licencias: Eliminar (baja lógica)


**Migraciones:**
- Se elimina el campo 'path' de la tabla 'certificate'
- Se agrego nuevo campo 'file' que representa el string base64 del certificado pdf
- Se modifica el 'upload_date' para que sea autocompletado