### PR TITLE
Feat: mejoras endpoints

### DIFF
--- a/backend/dashboard_api/serializers.py
+++ b/backend/dashboard_api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import HealthFirstUser, License
+from .models import Department, HealthFirstUser, License
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 
@@ -7,7 +7,7 @@ class HealthFirstUserSerializer(serializers.ModelSerializer):
     full_name = serializers.SerializerMethodField()
     role = serializers.SlugRelatedField(read_only=True, slug_field='name')
     department = serializers.SlugRelatedField(read_only=True, slug_field='name')
-
+    
     class Meta:
         model = HealthFirstUser
         fields = ['id','full_name', 'first_name', 'last_name','dni', 'date_of_birth', 'phone', 'role', 'email', 'department']
@@ -60,3 +60,8 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         
         return data
 
+
+class DepartmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Department
+        fields = ['id', 'name'] 

--- a/backend/dashboard_api/views.py
+++ b/backend/dashboard_api/views.py
@@ -385,12 +385,11 @@ def evaluate_license(request, id):
 
 
 # Detalle de licencia
-@csrf_exempt
+csrf_exempt
 @require_http_methods(["GET"])
 def get_license_detail(request, id):
     try:
-        #User = get_user_model()
-
+        # Try to fetch the license by ID
         try:
             license = License.objects.select_related("user", "status").get(license_id=id)
         except License.DoesNotExist:
@@ -398,18 +397,8 @@ def get_license_detail(request, id):
 
         user = request.user
 
-        # Validación de permisos. Descomentar cuando se implemente token.
-        #allowed_roles = ["supervisor", "admin"]
-        #if (license.user != user and user.role not in allowed_roles):
-        #    return JsonResponse({"error": "No tenés permisos para acceder a esta licencia."}, status=403)
-
-        # Datos del usuario solicitante
-        user_data = {
-            "first_name": license.user.first_name,
-            "last_name": license.user.last_name,
-            "email": license.user.email,
-            "department": getattr(license.user, "department", None),
-        }
+        # Serialize user data
+        user_data = HealthFirstUserSerializer(license.user).data
 
         # Datos de la licencia
         license_data = {

--- a/backend/dashboard_api/views.py
+++ b/backend/dashboard_api/views.py
@@ -389,7 +389,6 @@ def evaluate_license(request, id):
 @require_http_methods(["GET"])
 def get_license_detail(request, id):
     try:
-        # Try to fetch the license by ID
         try:
             license = License.objects.select_related("user", "status").get(license_id=id)
         except License.DoesNotExist:
@@ -397,7 +396,7 @@ def get_license_detail(request, id):
 
         user = request.user
 
-        # Serialize user data
+        
         user_data = HealthFirstUserSerializer(license.user).data
 
         # Datos de la licencia

--- a/backend/dashboard_api/views.py
+++ b/backend/dashboard_api/views.py
@@ -385,7 +385,7 @@ def evaluate_license(request, id):
 
 
 # Detalle de licencia
-csrf_exempt
+@csrf_exempt
 @require_http_methods(["GET"])
 def get_license_detail(request, id):
     try:
@@ -428,6 +428,7 @@ def get_license_detail(request, id):
             certificate_data = {
                 "validation": certificate.validation,
                 "upload_date": certificate.upload_date,
+                "file": certificate.file
             }
 
         return JsonResponse({

--- a/backend/dashboard_api/views.py
+++ b/backend/dashboard_api/views.py
@@ -189,19 +189,29 @@ def licenses_list(request):
     try:
         data = json.loads(request.body)
 
+        user_id = data.get('user_id')
+        show_all_users = data.get('show_all_users', False)
         status_filter = data.get('status')
         employee_name = data.get('employee_name', '').strip()
         page_number = data.get('page', 1)
         page_size = data.get('page_size', 10)
 
-        user = request.user
-        queryset = License.objects.filter(is_deleted=False) # Para no traer registros elimiandos
+        if not user_id:
+            return JsonResponse({'error': 'El campo user_id es requerido.'}, status=400)
+
+        # Obtenemos el usuario que hace la consulta
+        try:
+            current_user = HealthFirstUser.objects.get(id=user_id, is_deleted=False)
+        except HealthFirstUser.DoesNotExist:
+            return JsonResponse({'error': 'Usuario no encontradooo'}, status=404)
+
+        queryset = License.objects.filter(is_deleted=False) # No se traen las licencias eliminadas
 
         # Filtro por nombre de empleado
         if employee_name:
             queryset = queryset.filter(user__first_name__icontains=employee_name)
 
-        # Filtro por estados
+        # Filtro por estado
         if status_filter:
             status_filter = status_filter.lower()
             if status_filter == "approved":
@@ -211,10 +221,19 @@ def licenses_list(request):
             elif status_filter == "rejected":
                 queryset = queryset.filter(justified=False, closing_date__isnull=False)
 
-        # Filtro por rol
-        if hasattr(user, 'role') and user.role:
-            if user.role.name in ['analyst', 'employee']:
-                queryset = queryset.filter(user=user)
+        role_name = current_user.role.name if current_user.role else None
+
+        if role_name in ['employee', 'analyst']:
+            if role_name in ['employee', 'analyst']:
+                # Solo sus licencias (usa user_id como filtro principal)
+                queryset = queryset.filter(user__id=user_id)
+
+        elif role_name in ['admin', 'supervisor']:
+            if not show_all_users:
+                queryset = queryset.filter(user=current_user)
+            # Si show_all_users es True, vemos licencias de todos los usuarios
+        else:
+            queryset = queryset.none()
 
         queryset = queryset.order_by('-start_date')
 


### PR DESCRIPTION
**Features**
- Se suma un filtro 'user_id' por id de usuario en la request del endpoint de listar licencias.

- Se agrega nuevo campo **show_all_users** para determinar si el admin/supervisor obtiene todas las licencias o solo las propias. En el caso de analista/empleado sólo podrán ver sus propias licencias.

- Ahora se devuelve el file del certificado en la respuesta del endpoint de detalle de Licencia.

**Bugfix**
- Se corrigió un error en el endpoint de detalle de licencia, ya que estaba dando un error por un serializer de Deparment.

