### PR TITLE
add-endpoint-risk-prediction

### DIFF
--- a/backend/users/health_risk/risk_model.py
+++ b/backend/users/health_risk/risk_model.py
@@ -4,7 +4,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
 from sklearn.preprocessing import StandardScaler
-from risk_utils import generate_risk_dataframe
+from .risk_utils import generate_risk_dataframe
 import joblib
 import os
 from pathlib import Path

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -19,4 +19,6 @@ urlpatterns = [
     path('department/delete/<int:id>', delete_department, name='delete_department'),
     path('get_departments', get_departments, name='get_departments'),    
 
+
+    path('predict_health_risk', predict_health_risk, name='predict_health_risk'),
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -16,6 +16,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from licenses.utils.file_utils import *
 from messaging.services.brevo_email import *
+from .health_risk.risk_model import predict_risk
+from django.views.decorators.csrf import csrf_exempt
+
 
 class CustomTokenObtainPairView(TokenObtainPairView):
     serializer_class = CustomTokenObtainPairSerializer
@@ -361,6 +364,17 @@ def get_departments(request):
     except Exception as e:
         return JsonResponse({"error": str(e)}, status=500)
        
+
+@api_view(['GET'])
+@authentication_classes([JWTAuthentication])
+@permission_classes([IsAuthenticated])
+def predict_health_risk(request):
+    try:
+        risk_list=json.loads(predict_risk())
+    except Exception as e:
+        return JsonResponse({"Error inesperado al predecir riesgo": str(e)}, status=500)
+
+    return JsonResponse({"risk": risk_list}, status=200)
 
 
   


### PR DESCRIPTION
## 📌 Descripción

<!-- Explicá brevemente qué cambios implementa este PR y por qué son necesarios -->
- ¿Qué se resolvió?
- ¿Qué se agregó o eliminó?
Se agrega endpoint para predicción de riesgo.


---

## 🛠 Cambios realizados
- [ x] Nuevo feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentación
- [ ] Otros: ____________________

---

## 🔍 ¿Cómo probarlo?

<!-- Instrucciones para testear este PR -->
1. 
2. 
3. 

## 🧪 cURL (para testear endpoints)

```bash
# Describí brevemente qué hace esta petición
curl -X GET "localhost:8000/users/predict_health_risk" -H "Authorization: Bearer <TOKEN>"

Ejemplo de respuesta

"risk": [
        {
            "Nombre": "Admin",
            "Apellido": "Admin",
            "Edad": 35,
            "Email": "admin@admin.com",
            "Departamento_de_Riesgo": 0,
            "Cant_licencias_enfermedad": 0,
            "Cant_licencias_accidente": 0,
            "Riesgo": "Bajo Riesgo"
        },
        {
            "Nombre": "Fabian",
            "Apellido": "Hunt",
            "Edad": 31,
            "Email": "fabi.hunt93@gmail.com",
            "Departamento_de_Riesgo": 0,
            "Cant_licencias_enfermedad": 1,
            "Cant_licencias_accidente": 0,
            "Riesgo": "Bajo Riesgo"
        },
...
---

## ✅ Checklist
- [ ] Se aplican migraciones
- [ ] Todos los tests pasan correctamente
- [ x] No hay warnings o errores en consola
- [ ] Se actualizó la documentación (si aplica)
---

## 🧩 Issues relacionados

<!-- Si este PR cierra o se relaciona con una tarjeta -->


---

## 💬 Notas adicionales

<!-- Cualquier detalle adicional, limitación o algo que el revisor deba saber -->
