### PR TITLE
mesagges are added to the license request

### DIFF
--- a/backend/licenses/views.py
+++ b/backend/licenses/views.py
@@ -178,6 +178,10 @@ def create_license(request):
                 )
 
             license.assign_status()
+            if license.type and license.type.certificate_require and certificate_data is None:
+                MessengerService.send_upload_license_without_certificate_message(license)
+            else:
+                MessengerService.send_upload_license_message(license)
 
         return JsonResponse({'message': 'Licencia solicitada exitosamente.'}, status=200)
 

--- a/backend/messaging/services/messenger.py
+++ b/backend/messaging/services/messenger.py
@@ -21,12 +21,13 @@ class MessengerService:
 
     def send_rejected_license_message(license):
         user = license.user
-        subject = "Licencia rechazada"
+        subject = f"Licencia con id  {license.license_id} rechazada"
         message = (
             f"¡Hola {user.first_name} {user.last_name}!\n\n"
             f"Lamentamos informarte que hemos rechazado tu licencia de {license.type.name}.\n\n"
             f"Motivo:\n{license.status.evaluation_comment}\n\n"
             "Para más detalles contactate con tu supervisor.\n\n"
+            "ID de licencia: " + str(license.license_id) + "\n\n"
             "¡Gracias por confiar en nosotros!\n"
             "Equipo Health First"
         )
@@ -36,10 +37,11 @@ class MessengerService:
 
     def send_approved_license_message(license):
         user = license.user
-        subject = "Solicitud de licencia aprobada"
+        subject = f"Solicitud de licencia con id  {license.license_id} aprobada"
         message = (
             f"¡Hola {user.first_name} {user.last_name}!\n\n"
             f"Es de nuestro gusto informarte que hemos aprobado tu licencia de {license.type.name}.\n\n"
+            f"ID de licencia: " + str(license.license_id) + "\n\n"
             "¡Gracias por confiar en nosotros!\n"
             "Equipo Health First"
         )
@@ -49,12 +51,13 @@ class MessengerService:
 
     def send_expired_license_message(license):
         user=license.user
-        subject = "Solicitud de licencia expirada"
+        subject = f"Solicitud de licencia con id  {license.license_id} expirada"
         message = (
             f"¡Hola {user.first_name} {user.last_name}!\n\n"
             f"Te informamos que tu licencia de {license.type.name} ha expirado "
             "debido a que no cargaste tu certificado en el tiempo requerido.\n"
             "Cualquier duda contactate con tu supervisor.\n\n"
+            f"ID de licencia: " + str(license.license_id) + "\n\n"
             "¡Gracias por confiar en nosotros!\n"
             "Equipo Health First"
         )
@@ -63,12 +66,13 @@ class MessengerService:
 
     def send_license_expired_tomorrow(license):
         user = license.user
-        subject = "Tu solicitud de licencia expira pronto"
+        subject = f"Tu solicitud de licencia con id  {license.license_id} expira pronto"
         message = (
             f"¡Hola {user.first_name} {user.last_name}!\n\n"
             f"Te informamos que tu solicitud de licencia de {license.type.name} vence mañana.\n"
             "Tenes entre hoy y mañana para cargar tu certificado.\n"
             "Cualquier duda contactate con tu supervisor.\n\n"
+            f"ID de licencia: " + str(license.license_id) + "\n\n"
             "¡Gracias por confiar en nosotros!\n"
             "Equipo Health First"
         )
@@ -76,16 +80,45 @@ class MessengerService:
 
     def send_last_day_to_upload_certificate_message(license):
         user = license.user
-        subject = "Tu solicitud de licencia expira hoy"
+        subject = "Tu solicitud de licencia con id {license.license_id} expira hoy"
         message = (
             f"¡Hola {user.first_name} {user.last_name}!\n\n"
             f"Te informamos que tu solicitud de licencia de {license.type.name} vence hoy.\n"
             "Hoy es el último día para cargar tu certificado.\n"
             "Cualquier duda contactate con tu supervisor.\n\n"
+            f"ID de licencia: " + str(license.license_id) + "\n\n"
             "¡Gracias por confiar en nosotros!\n"
             "Equipo Health First"
         )
         MessengerService.send_personalized_message(user, subject, message)
+
+    def send_upload_license_without_certificate_message(license):
+        user = license.user
+        subject = f"Solicitud de licencia con id {license.license_id}, sin certificado"
+        message = (
+            f"¡Hola {user.first_name} {user.last_name}!\n\n"
+            f"Te informamos que tu solicitud de licencia de {license.type.name} se registro con exito.\n"
+            "Recuerda que tenes que cargar tu certificado para que la puedan aprobar.\n"
+            "Verifica los dias de tolerancia en las politicas de la empresa.\n\n"
+            f"ID de licencia: " + str(license.license_id) + "\n\n"
+            "¡Gracias por confiar en nosotros!\n"
+            "Equipo Health First"
+        )
+        MessengerService.send_personalized_message(user, subject, message)
+
+
+    def send_upload_license_message(license):
+        user = license.user
+        subject = f"Solicutid de licencia {license.license_id}, certificado cargado"
+        message = (
+            f"¡Hola {user.first_name} {user.last_name}!\n\n"
+            f"Te informamos que tu solicitud de licencia de {license.type.name} se registro con exito.\n"
+            "Te avisaremos cuando tu licencia sea evaluada por un supervisor\n"
+            f"ID de licencia: " + str(license.license_id) + "\n\n"
+            "¡Gracias por confiar en nosotros!\n"
+            "Equipo Health First"   
+        )
+        MessengerService.send_personalized_message(user, subject, message)  
 
 
     def send_personalized_message(user, subject, message):


### PR DESCRIPTION
## 📌 Descripción

<!-- Explicá brevemente qué cambios implementa este PR y por qué son necesarios -->
- ¿Qué se resolvió?
- ¿Qué se agregó o eliminó?
Se agregaro envio de mails y telegram a solicitud de licencias con y sin certificado.
---

## 🛠 Cambios realizados
- [x] Nuevo feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentación
- [ ] Otros: ____________________

---

## 🔍 ¿Cómo probarlo?
Se puede testear creando solicitudes de licencias que requieran certificados y sin cargar el mismo. 
<!-- Instrucciones para testear este PR -->
1. 
2. 
3. 

## 🧪 cURL (para testear endpoints)

```bash
# Describí brevemente qué hace esta petición
curl -X GET "http://localhost:8080/api/" -H "Authorization: Bearer <TOKEN>"


---

## ✅ Checklist
- [ ] Se aplican migraciones
- [ ] Todos los tests pasan correctamente
- [ ] No hay warnings o errores en consola
- [ ] Se actualizó la documentación (si aplica)
---

## 🧩 Issues relacionados

<!-- Si este PR cierra o se relaciona con una tarjeta -->


---

## 💬 Notas adicionales

<!-- Cualquier detalle adicional, limitación o algo que el revisor deba saber -->
