### PR TITLE
add pagination into email events

### DIFF
--- a/backend/messaging/services/brevo_email.py
+++ b/backend/messaging/services/brevo_email.py
@@ -21,7 +21,7 @@ def get_brevo_stats():
         return response.json()  
     return None
 
-def get_brevo_events(days=7, email=None, event_type=None):
+def get_brevo_events(days=7, email=None, event_type=None,limit=10, offset=0):
     """
     Obtiene eventos recientes de Brevo
     
@@ -38,7 +38,8 @@ def get_brevo_events(days=7, email=None, event_type=None):
     
     params = {
         "days": days,
-        "limit": 100  # Máximo por llamada
+        "limit": limit,
+        "offset": offset
     }
     
     # Agregar filtros opcionales
@@ -50,64 +51,11 @@ def get_brevo_events(days=7, email=None, event_type=None):
     response = requests.get(url, headers=headers, params=params)
     if response.status_code == 200:
         events = response.json().get('events', [])
-        # Filtrar para excluir eventos de tipo "requests"
-        filtered_events = [event for event in events if event.get('event') != 'requests']
-        return {'events': filtered_events}
+        return {'events': events}
     return {'events': []}
-
-def get_all_brevo_events(days=7, email=None, event_type=None):
-    """
-    Obtiene TODOS los eventos usando paginación automática
-    """
-    all_events = []
-    offset = 0
     
-    while True:
-        url = "https://api.brevo.com/v3/smtp/statistics/events"
-        headers = {
-            "accept": "application/json",
-            "api-key": settings.BREVO_API_KEY,
-        }
-        
-        params = {
-            "days": days,
-            "limit": 100,
-            "offset": offset
-        }
-        
-        if email:
-            params["email"] = email
-        if event_type:
-            params["event"] = event_type
-        
-        response = requests.get(url, headers=headers, params=params)
-        
-        if response.status_code != 200:
-            break
-            
-        data = response.json()
-        events = data.get('events', [])
-        
-        if not events:
-            break
-            
-        all_events.extend(events)
-        
-        # Si recibimos menos de 100, ya no hay más
-        if len(events) < 100:
-            break
-            
-        offset += 100
-    
-    return all_events
-
-def get_recent_opens(days=7):
-    """Obtiene solo los eventos de apertura"""
-    return get_all_brevo_events(days=days, event_type="opened")
-
-
-def get_user_activity(email, days=30):
+def get_user_activity(email, days=30,offset=0,limit=10):
     """Obtiene toda la actividad de un usuario específico"""
-    return get_all_brevo_events(days=days, email=email)
+    return get_brevo_events(days=days, email=email,offset=offset,limit=limit)
 
 

--- a/backend/messaging/services/messenger.py
+++ b/backend/messaging/services/messenger.py
@@ -121,8 +121,8 @@ class MessengerService:
         MessengerService.send_personalized_message(user, subject, message)  
 
 
-#    def send_personalized_message(user, subject, message):
-#        send_email(subject, message, user.email)
-#        if user.is_telegram_suscriptor:
-#            TelegramService.send_message(chat_id=user.telegram_id, message=message)
+    def send_personalized_message(user, subject, message):
+        send_email(subject, message, user.email)
+        if user.is_telegram_suscriptor:
+            TelegramService.send_message(chat_id=user.telegram_id, message=message)
 

--- a/backend/messaging/urls.py
+++ b/backend/messaging/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
     #url de email
     path('get_email_stats', get_email_stats,name='get-email-stats'),
     path('get_email_events', get_email_events,name='get-email-events'),
-    path('get_user_email_events/<int:id>', get_user_email_events,name='get-user-email-events'),  
+    path('get_user_email_events', get_user_email_events,name='get-user-email-events'),  
 
     path('send_personalized_message', send_personalized_message,name='send-personalized-message'),
 ]

--- a/backend/messaging/views.py
+++ b/backend/messaging/views.py
@@ -97,34 +97,41 @@ def get_email_stats(request):
     return JsonResponse({"stats": stats}, status=200)
 
 
-@api_view(['GET'])
+@api_view(['POST'])
 @authentication_classes([JWTAuthentication])
 @permission_classes([IsAuthenticated])
 def get_email_events(request):
     try:
-        events=get_brevo_events()
+        data= json.loads(request.body)
+        limit=data.get('limit',10)
+        offset=data.get('offset', 0)
+        events=get_brevo_events(limit=limit, offset=offset)
     except Exception as e:
         return JsonResponse({"error": str(e)}, status=500)
 
     return JsonResponse({"events": events}, status=200)
     
-@api_view(['GET'])
+@api_view(['POST'])
 @authentication_classes([JWTAuthentication])
 @permission_classes([IsAuthenticated])
-def get_user_email_events(request, id):
+def get_user_email_events(request):
+    data= json.loads(request.body)
+    id=data.get('user_id')
+    limit=data.get('limit',10)
+    offset=data.get('offset', 0)
+    if not id:
+        return JsonResponse({"error": "El id del usuario es requerido"}, status=400)
     try:
         user = HealthFirstUser.objects.get(id=id, is_deleted=False)
     except HealthFirstUser.DoesNotExist:
         return JsonResponse({"error": "El usuario no existe"}, status=404)
     
     try:
-        events = get_user_activity(user.email)
-        # Filto para excluir eventos de tipo "requests"
-        filtered_events = [event for event in events if event.get('event') != 'requests']
+        events = get_user_activity(email=user.email, limit=limit, offset=offset)
     except Exception as e:
         return JsonResponse({"error": str(e)}, status=500)
 
-    return JsonResponse({"events": filtered_events}, status=200)
+    return JsonResponse({"events": events}, status=200)
     
 
 @api_view(['POST'])

--- a/backend/users/health_risk/risk_model.py
+++ b/backend/users/health_risk/risk_model.py
@@ -114,8 +114,3 @@ def predict_risk():
 
     print(json_results)
     return json_results
-
-"""--------------------------------"""
-df_training=pd.read_csv("HealthFirst/backend/users/health_risk/dataset_risk.csv")
-training_model(df_training)
-predict_risk()


### PR DESCRIPTION
## 📌 Descripción

<!-- Explicá brevemente qué cambios implementa este PR y por qué son necesarios -->
- ¿Qué se resolvió?
- ¿Qué se agregó o eliminó?

Se agrego paginacion a get_email_events y a get_email_user_events.
IMPORTANTE:
Los dos metodos pasaron a ser POST para poder recibir parametros multiples y no ensuciar la URL.


---

## 🛠 Cambios realizados
- [ ] Nuevo feature
- [ ] Bug fix
- [ x] Refactor
- [ ] Documentación
- [ ] Otros: ____________________

---

## 🔍 ¿Cómo probarlo?

<!-- Instrucciones para testear este PR -->
1. 
2. 
3. 

## 🧪 cURL (para testear endpoints)

```bash
# Describí brevemente qué hace esta petición

Parametros:
user_id= obligatorio
limit= cantidad de registros por pagina
offset= numero de registro por donde empieza la paginacion
curl -X POST "http://localhost:8000/messaging/get_email_events" \
  -H "Authorization: Bearer <TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{"user_id": "2", "limit": "20", "offset": "1"}'

--------------------------------------------------------------------------------------
Parametros
limit= cantidad de registros por pagina
offset= numero de registro por donde empieza la paginacion
curl -X POST "http://localhost:8000/messaging/get_email_events" \
  -H "Authorization: Bearer <TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{ "limit": "20", "offset": "1"}'
 
IMPORTANTE
No hay forma de saber el total de registros por lo cual no se sabe de antemano cuantas paginas se necesitan. 
Si se pasa un offset fuera de rango devolvera vacio el parametro events.




---

## ✅ Checklist
- [ ] Se aplican migraciones
- [ ] Todos los tests pasan correctamente
- [ ] No hay warnings o errores en consola
- [ ] Se actualizó la documentación (si aplica)
---

## 🧩 Issues relacionados

<!-- Si este PR cierra o se relaciona con una tarjeta -->


---

## 💬 Notas adicionales

<!-- Cualquier detalle adicional, limitación o algo que el revisor deba saber -->
