### PR TITLE
feat: adds employee anomaly endpoint

### DIFF
--- a/backend/licenses/anomalies/isolation_forest.py
+++ b/backend/licenses/anomalies/isolation_forest.py
@@ -266,7 +266,7 @@ def anomalies_employees(data): #recibe un dataframe
 
     return(data)
 
-def get_empleoyee_anomalies(start_date=None, end_date=None): #FUNCION PRINCIPAL QUE SE USARA EN EL FRONT
+def get_employee_anomalies(start_date=None, end_date=None): #FUNCION PRINCIPAL QUE SE USARA EN EL FRONT
     df = create_dataFrame_empleados(start_date, end_date)
     if df.empty:
         cols = ['employee_id','total_requests', 'required_days', 'required_days_rate','seniority_days','days_per_year']

--- a/backend/licenses/urls.py
+++ b/backend/licenses/urls.py
@@ -16,5 +16,6 @@ urlpatterns = [
 
     path('certificate/coherence', upload_base64_file,name='upload_base64_file'),
 
-    path('anomalies/supervisor', supervisor_anomalies, name='get_anomalies_view')     
+    path('anomalies/supervisor', supervisor_anomalies, name='get_supervisor_anomalies_view'),
+    path('anomalies/employee', employee_anomalies, name='get_employee_anomalies_view')         
 ]


### PR DESCRIPTION
## 📌 Descripción

Se agrega endpoint para consumir la función de anomalías de empleado.

---

## 🛠 Cambios realizados
- [x] Nuevo feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentación
- [ ] Otros: ____________________

---


## 🧪 cURL (para testear endpoints)

```bash
curl --location 'http://localhost:8000/licenses/anomalies/employee?start_date=2024-01-01&end_date=2024-12-31&is_anomaly=true&employee_id=2' \
--header 'Authorization: Bearer ' \
--header 'Cookie: metabase.DEVICE=c58bf24a-513c-4377-82c7-e1848087217f'


---

## ✅ Checklist
- [ ] Se aplican migraciones
- [ ] Todos los tests pasan correctamente
- [x] No hay warnings o errores en consola
- [x] Se actualizó la documentación (si aplica)
---

## 💬 Notas adicionales
Todos los filtros son opcionales.